### PR TITLE
Adding Parse overload for low allocations using Span<T>

### DIFF
--- a/NUlid.Tests/UlidTests.cs
+++ b/NUlid.Tests/UlidTests.cs
@@ -544,6 +544,13 @@ namespace NUlid.Tests
         }
 
         [TestMethod]
+        public void Parse_WithSpan_Allows_Hyphens()
+        {
+            Assert.AreEqual(Ulid.Parse("01BX5ZZKBKACTAV9WEVGEMMVRZ".AsSpan()), Ulid.Parse("01BX5ZZKBK-ACTA-V9WE-VGEM-MVRZ".AsSpan()));
+            Assert.AreEqual(Ulid.Parse("01BX5ZZKBKACTAV9WEVGEMMVRZ".AsSpan()), Ulid.Parse("01BX5ZZKBK-ACTAV9WEVGEMMVRZ".AsSpan()));
+        }
+
+        [TestMethod]
         public void GreaterThanOperator()
         {
             Assert.IsTrue(new Ulid("01BX5ZZKBKACTAV9WEVGEMMVS1") > new Ulid("01BX5ZZKBKACTAV9WEVGEMMVS0"));

--- a/NUlid.Tests/UlidTests.cs
+++ b/NUlid.Tests/UlidTests.cs
@@ -96,6 +96,16 @@ namespace NUlid.Tests
         }
 
         [TestMethod]
+        public void Ulid_Parse_WithSpan_ParsesCorrectly()
+        {
+            var ulid = Ulid.NewUlid();
+            var target = Ulid.Parse(ulid.ToString().AsSpan());
+
+            Assert.IsTrue(target.Random.SequenceEqual(ulid.Random));
+            Assert.AreEqual(ulid.Time, target.Time);
+        }
+
+        [TestMethod]
         public void Ulid_EqualsOperator_WorksCorrectly()
         {
             var a = Ulid.NewUlid();
@@ -264,6 +274,29 @@ namespace NUlid.Tests
         }
 
         [TestMethod]
+        public void Ulid_TryParse_WithSpan_WorksCorrectly()
+        {
+            Assert.IsFalse(Ulid.TryParse("X".AsSpan(), out var r1));
+            Assert.AreEqual(Ulid.Empty, r1);
+
+            Assert.IsFalse(Ulid.TryParse(string.Empty.AsSpan(), out var r2));
+            Assert.AreEqual(Ulid.Empty, r2);
+
+            Assert.IsFalse(Ulid.TryParse(Span<char>.Empty, out var r3));
+            Assert.AreEqual(Ulid.Empty, r3);
+
+            Assert.IsTrue(Ulid.TryParse(Ulid.MinValue.ToString().AsSpan(), out var r4));
+            Assert.IsTrue(Ulid.MinValue == r4);
+
+            Assert.IsTrue(Ulid.TryParse(Ulid.MaxValue.ToString().AsSpan(), out var r5));
+            Assert.IsTrue(Ulid.MaxValue == r5);
+
+            var target = Ulid.NewUlid(KNOWNTIMESTAMP_DTO, new FakeUlidRng());
+            Assert.IsTrue(Ulid.TryParse((KNOWNTIMESTAMP_STRING + KNOWNRANDOMSEQ_STRING).AsSpan(), out var r6));
+            Assert.AreEqual(r6, target);
+        }
+
+        [TestMethod]
         public void Ulid_Parse_WorksCorrectly()
         {
             Assert.AreEqual(Ulid.MinValue, Ulid.Parse(Ulid.MinValue.ToString()));
@@ -272,6 +305,17 @@ namespace NUlid.Tests
             var target = Ulid.NewUlid(KNOWNTIMESTAMP_DTO, new FakeUlidRng());
             Assert.AreEqual(Ulid.Parse(KNOWNTIMESTAMP_STRING + KNOWNRANDOMSEQ_STRING), target);
             Assert.AreEqual(new Ulid(KNOWNTIMESTAMP_STRING + KNOWNRANDOMSEQ_STRING), target);
+        }
+
+        [TestMethod]
+        public void Ulid_Parse_WithSpan_WorksCorrectly()
+        {
+            Assert.AreEqual(Ulid.MinValue, Ulid.Parse(Ulid.MinValue.ToString().AsSpan()));
+            Assert.AreEqual(Ulid.MaxValue, Ulid.Parse(Ulid.MaxValue.ToString().AsSpan()));
+
+            var target = Ulid.NewUlid(KNOWNTIMESTAMP_DTO, new FakeUlidRng());
+            Assert.AreEqual(Ulid.Parse((KNOWNTIMESTAMP_STRING + KNOWNRANDOMSEQ_STRING).AsSpan()), target);
+            Assert.AreEqual(new Ulid((KNOWNTIMESTAMP_STRING + KNOWNRANDOMSEQ_STRING).AsSpan()), target);
         }
 
         [TestMethod]
@@ -290,13 +334,22 @@ namespace NUlid.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void Ulid_Parse_ThrowsArgumentNullException_OnNull() => Ulid.Parse(null);
 
+
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void Ulid_Parse_ThrowsArgumentNullException_OnEmptyString() => Ulid.Parse(string.Empty);
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Ulid_Parse_WithSpan_ThrowsArgumentNullException_OnEmptyString() => Ulid.Parse(Span<char>.Empty);
+
+        [TestMethod]
         [ExpectedException(typeof(FormatException))]
         public void Ulid_Parse_ThrowsFormatException_OnInvalidLengthString() => Ulid.Parse("TEST");
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void Ulid_Parse_WithSpan_ThrowsFormatException_OnInvalidLengthString() => Ulid.Parse("TEST".AsSpan());
 
         [TestMethod]
         public void Ulid_Parse_Handles_IiLl_TreatedAs_One()  //https://www.crockford.com/base32.html

--- a/NUlid/NUlid.csproj
+++ b/NUlid/NUlid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Authors>RobIII</Authors>
     <Company>RobIII</Company>
     <PackageId>NUlid</PackageId>
@@ -16,13 +16,13 @@
     <PackageReleaseNotes>Monotonic UlidRng no longer allows specifying the mask; we default to masking out the MSB of the random part which gives us at least 2^79 bits before running into a sequenceoverflow. Also fixed a bug in the MonotonicUlidRng that caused an InvalidOperationException("Clock moved backwards; this is not supported.")</PackageReleaseNotes>
     <IncludeSource>true</IncludeSource>
     <Description>A .Net ULID implementation</Description>
-    <Version>1.5</Version>
+    <Version>1.6</Version>
     <LangVersion>latest</LangVersion>
     <PackageIcon>logo.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DefineConstants>TRACE;RELEASE;NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">


### PR DESCRIPTION
Please consider this PR for enabling low allocation parsing of Ulid.

- I've fixed a bug in current Parse method which was only sending through 6 characters instead of 16 to `FromBase32`
- I've added .netstandard 2.1 as another target framework to enable use of Spans 
- I've created overload of the `Parse` method to allow passing `ReadOnlySpan<char>` as argument to avoid the need to allocate new strings if that can be avoided.
- I've added overload to the `FromBase32` to avoid string allocation when called from `Parse` (although a small stack allocation will happen due to `Slice`-ing a Span, but it should be more lightweight than allocating a new substring)
- I've made the "-" hyphen a constant to avoid allocation on every `Parse` call