### PR TITLE
Bugfix: random string is only 16 characters, not 26

### DIFF
--- a/NUlid/Ulid.cs
+++ b/NUlid/Ulid.cs
@@ -325,7 +325,10 @@ namespace NUlid
                 }
             }
 
-            return new Ulid(ByteArrayToDateTimeOffset(FromBase32(stripped.Substring(0, 10))), FromBase32(stripped.Substring(10, 26)));
+            var timeString = stripped.Substring(0, 10);
+            var randString = stripped.Substring(10, 16);
+
+            return new Ulid(ByteArrayToDateTimeOffset(FromBase32(timeString)), FromBase32(randString));
         }
 #elif NETSTANDARD2_1
         /// <summary>


### PR DESCRIPTION
This fixes an out-of-bounds issue on UWP and likely other platforms that are limited to Netstandard 2.0.