### PR TITLE
run tests on .NET 4.x

### DIFF
--- a/NUlid.Tests/NUlid.Tests.csproj
+++ b/NUlid.Tests/NUlid.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <LangVersion>Latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/NUlid.Tests/UlidTests.cs
+++ b/NUlid.Tests/UlidTests.cs
@@ -485,12 +485,12 @@ namespace NUlid.Tests
             var target = Ulid.NewUlid(ts);
             var rng = new MicrosecondUlidRng(new FakeUlidRng());
 
-            var microsecond = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 1000);
+            var microsecond = TimeSpan.TicksPerMillisecond / 1000;
 
-            Assert.AreEqual("01E1N33600000DBEEFDEADBEEF", Ulid.NewUlid(target.Time.Add(microsecond * 0), rng).ToString());
-            Assert.AreEqual("01E1N3360000MDBEEFDEADBEEF", Ulid.NewUlid(target.Time.Add(microsecond * 1), rng).ToString());
-            Assert.AreEqual("01E1N33600018DBEEFDEADBEEF", Ulid.NewUlid(target.Time.Add(microsecond * 2), rng).ToString());
-            Assert.AreEqual("01E1N3360001WDBEEFDEADBEEF", Ulid.NewUlid(target.Time.Add(microsecond * 3), rng).ToString());
+            Assert.AreEqual("01E1N33600000DBEEFDEADBEEF", Ulid.NewUlid(target.Time.AddTicks(microsecond * 0), rng).ToString());
+            Assert.AreEqual("01E1N3360000MDBEEFDEADBEEF", Ulid.NewUlid(target.Time.AddTicks(microsecond * 1), rng).ToString());
+            Assert.AreEqual("01E1N33600018DBEEFDEADBEEF", Ulid.NewUlid(target.Time.AddTicks(microsecond * 2), rng).ToString());
+            Assert.AreEqual("01E1N3360001WDBEEFDEADBEEF", Ulid.NewUlid(target.Time.AddTicks(microsecond * 3), rng).ToString());
         }
 
         [TestMethod]


### PR DESCRIPTION
The netstandard2.0 code was not being tested. Although, it had no issues on netcoreapp3.1 only on .NET 4.x series.

Needed to modify the test because .NET 4.8 doesn't support using the * operator on a TimeSpan

You will need to merge https://github.com/RobThree/NUlid/pull/19 in order for the checks on this one to pass.

The failing test is the ArgumentOutOfRangeException noted here: https://github.com/RobThree/NUlid/issues/18