### PR TITLE
Reduced allocations in hot methods

### DIFF
--- a/NUlid.Tests/FakeUlidRng.cs
+++ b/NUlid.Tests/FakeUlidRng.cs
@@ -1,7 +1,6 @@
-﻿using NUlid.Rng;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
+using NUlid.Rng;
 
 namespace NUlid.Tests;
 
@@ -14,13 +13,15 @@ namespace NUlid.Tests;
 public class FakeUlidRng : IUlidRng
 {
     //Values specifically chosen to make the result spell DEADBEEFDEADBEEF
-    public static readonly IReadOnlyList<byte> DEFAULTRESULT = new byte[] { 107, 148, 213, 185, 207, 107, 148, 213, 185, 207 };
+    public static readonly byte[] DEFAULTRESULT = new byte[] { 107, 148, 213, 185, 207, 107, 148, 213, 185, 207 };
     private readonly byte[] _desiredresult;
 
     public FakeUlidRng()
-        : this(DEFAULTRESULT.ToArray()) { }
+        : this(DEFAULTRESULT.ToArray()) { }     // make a copy
 
     public FakeUlidRng(byte[] desiredResult) => _desiredresult = desiredResult;
 
     public byte[] GetRandomBytes(DateTimeOffset dateTime) => _desiredresult;
+
+    public void GetRandomBytes(Span<byte> buffer, DateTimeOffset dateTime) => _desiredresult.AsSpan().CopyTo(buffer);
 }

--- a/NUlid.Tests/UlidTests.cs
+++ b/NUlid.Tests/UlidTests.cs
@@ -323,7 +323,7 @@ public class UlidTests
     public void Ulid_Parse_ThrowsFormatException_OnInvalidString2() => Ulid.Parse(KNOWNTIMESTAMP_STRING + KNOWNRANDOMSEQ_STRING.Replace('E', '{')); // Test char after last index in C2B32 array
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
+    [ExpectedException(typeof(ArgumentException))]
     public void Ulid_Constructor_ThrowsArgumentException_OnNullByteArray() => new Ulid((byte[])null);
 
     [TestMethod]
@@ -338,6 +338,7 @@ public class UlidTests
     [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void Ulid_NewUlid_ThrowsArgumentOutOfRangeException_OnTimestamp() => Ulid.NewUlid(Ulid.MinValue.Time.AddMilliseconds(-1));
 
+#if NETFRAMEWORK
     [TestMethod]
     [ExpectedException(typeof(InvalidOperationException))]
     public void Ulid_NewUlid_ThrowsInvalidOperationException_OnRNGReturningInsufficientBytes()
@@ -345,6 +346,7 @@ public class UlidTests
         var rng = new FakeUlidRng(new byte[] { 1, 2, 3 });
         Ulid.NewUlid(rng);
     }
+#endif
 
     [TestMethod]
     public void Ulid_TypeConverter_CanGetUsableConverter()

--- a/NUlid/NUlid.csproj
+++ b/NUlid/NUlid.csproj
@@ -34,6 +34,10 @@
 		<DocumentationFile>bin\release\NUlid.xml</DocumentationFile>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Memory" Version="4.5.5" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<None Include="..\logo.png">
 			<Pack>True</Pack>

--- a/NUlid/Rng/BaseUlidRng.cs
+++ b/NUlid/Rng/BaseUlidRng.cs
@@ -10,7 +10,7 @@ public abstract class BaseUlidRng : IUlidRng
     /// <summary>
     /// Default number of random bytes generated
     /// </summary>
-    protected const int RANDLEN = 10;
+    protected internal const int RANDLEN = 10;
 
     /// <summary>
     /// Creates and returns random bytes.
@@ -18,6 +18,9 @@ public abstract class BaseUlidRng : IUlidRng
     /// <param name="dateTime">DateTime for which the random bytes need to be generated; can be ignored but provides context.</param>
     /// <returns>Random bytes.</returns>
     public abstract byte[] GetRandomBytes(DateTimeOffset dateTime);
+
+    /// <inheritdoc/>
+    public abstract void GetRandomBytes(Span<byte> buffer, DateTimeOffset dateTime);
 
     /// <summary>
     /// Returns the default <see cref="IUlidRng"/> used when no <see cref="IUlidRng"/> is specified.

--- a/NUlid/Rng/CSUlidRng.cs
+++ b/NUlid/Rng/CSUlidRng.cs
@@ -28,4 +28,27 @@ public class CSUlidRng : BaseUlidRng
         return buffer;
     }
 #endif
+
+    /// <summary>
+    /// Fills the <paramref name="buffer"/> with returns cryptographically secure random bytes.
+    /// </summary>
+    /// <param name="buffer">The buffer to fill with cryptographically secure random bytes.</param>
+    /// <param name="dateTime">>DateTime for which the random bytes need to be generated; is ignored.</param>
+    /// <exception cref="ArgumentException">The buffer is too small.</exception>
+    public override void GetRandomBytes(Span<byte> buffer, DateTimeOffset dateTime)
+    {
+#if NET6_0_OR_GREATER
+        if (buffer.Length < RANDLEN)
+        {
+            Throw(buffer.Length);
+            static void Throw(int len) => throw new ArgumentException($"The given buffer must be at least {RANDLEN} bytes long, actual: {len}");
+        }
+
+        RandomNumberGenerator.Fill(buffer);
+#else
+        var tmp = new byte[RANDLEN];
+        _rng.GetBytes(tmp);
+        tmp.AsSpan().CopyTo(buffer);
+#endif
+    }
 }

--- a/NUlid/Rng/IUlidRng.cs
+++ b/NUlid/Rng/IUlidRng.cs
@@ -13,4 +13,11 @@ public interface IUlidRng
     /// <param name="dateTime">DateTime for which the random bytes need to be generated; can be ignored but provides context.</param>
     /// <returns>Random bytes.</returns>
     byte[] GetRandomBytes(DateTimeOffset dateTime);
+
+    /// <summary>
+    /// Fills the <paramref name="buffer"/> with random bytes.
+    /// </summary>
+    /// <param name="buffer">The buffer to fill with random bytes.</param>
+    /// <param name="dateTime">DateTime for which the random bytes need to be generated; can be ignored but provides context.</param>
+    void GetRandomBytes(Span<byte> buffer, DateTimeOffset dateTime);
 }

--- a/NUlid/Rng/SimpleUlidRng.cs
+++ b/NUlid/Rng/SimpleUlidRng.cs
@@ -25,6 +25,29 @@ public class SimpleUlidRng : BaseUlidRng
     }
 
     /// <summary>
+    /// Fills the <paramref name="buffer"/> with random bytes.
+    /// </summary>
+    /// <param name="buffer">The buffer to fill with random bytes.</param>
+    /// <param name="dateTime">DateTime for which the random bytes need to be generated; is ignored.</param>
+    /// <exception cref="ArgumentException">The buffer is too small.</exception>
+    public override void GetRandomBytes(Span<byte> buffer, DateTimeOffset dateTime)
+    {
+        if (buffer.Length < RANDLEN)
+        {
+            Throw(buffer.Length);
+            static void Throw(int len) => throw new ArgumentException($"The given buffer must be at least {RANDLEN} bytes long, actual: {len}");
+        }
+
+#if NET6_0_OR_GREATER
+        Random.Shared.NextBytes(buffer);
+#else
+        var tmp = new byte[RANDLEN];
+        ThreadLocalRandom.Instance.NextBytes(tmp);
+        tmp.AsSpan().CopyTo(buffer);
+#endif
+    }
+
+    /// <summary>
     /// Convenience class for dealing with randomness.
     /// </summary>
     /// <remarks>https://codeblog.jonskeet.uk/2009/11/04/revisiting-randomness/</remarks>


### PR DESCRIPTION
And used some low-hanging perf-tricks.

Compare especially the allocated column with the [one from the ReadMe](https://github.com/RobThree/NUlid#performance).

```

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19045.2364)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.101
  [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2

|                               Method |      Mean |    Error |    StdDev |    Median |   Gen0 | Allocated |
|------------------------------------- |----------:|---------:|----------:|----------:|-------:|----------:|
|                       Guid.NewGuid() |  90.99 ns | 1.783 ns |  1.392 ns |  90.81 ns |      - |         - |
|          Ulid.NewUlid(SimpleUlidRng) |  81.27 ns | 1.339 ns |  1.187 ns |  81.06 ns |      - |         - |
|              Ulid.NewUlid(CSUlidRng) | 183.88 ns | 3.715 ns |  7.997 ns | 184.12 ns |      - |         - |
| Ulid.NewUlid(SimpleMonotonicUlidRng) | 110.69 ns | 2.241 ns |  3.489 ns | 110.36 ns |      - |         - |
|     Ulid.NewUlid(CSMonotonicUlidRng) | 104.62 ns | 2.130 ns |  2.367 ns | 104.33 ns |      - |         - |
|                   Guid.Parse(string) | 297.19 ns | 5.884 ns |  8.248 ns | 294.01 ns | 0.0305 |      96 B |
|                   Ulid.Parse(string) | 383.53 ns | 7.719 ns | 16.113 ns | 379.30 ns | 0.0587 |     184 B |
|                      Guid.ToString() | 242.71 ns | 3.464 ns |  3.071 ns | 242.39 ns | 0.0305 |      96 B |
|                      Ulid.ToString() | 243.36 ns | 5.451 ns | 15.902 ns | 238.51 ns | 0.0253 |      80 B |
|                   `new Guid(byte[])` |  18.79 ns | 0.546 ns |  1.610 ns |  19.07 ns | 0.0127 |      40 B |
|                   `new Ulid(byte[])` |  22.31 ns | 0.566 ns |  1.668 ns |  22.64 ns | 0.0127 |      40 B |
|                   Guid.ToByteArray() | 107.64 ns | 2.221 ns |  4.332 ns | 107.81 ns | 0.0126 |      40 B |
|                   Ulid.ToByteArray() | 184.90 ns | 3.672 ns |  7.583 ns | 182.43 ns | 0.0126 |      40 B |
|                        Ulid.ToGuid() | 177.62 ns | 3.607 ns |  5.615 ns | 176.49 ns |      - |         - |
|                     `new Ulid(Guid)` | 113.43 ns | 1.943 ns |  1.817 ns | 113.40 ns | 0.0126 |      40 B |
|                   `new Ulid(Guid)`   | 99.74 ns  | 2.028 ns | 5.343 ns  | 97.46 ns  |      - |         - |
```

---

Some questions:
* is this approach usable in this repo?
* do you care about big-endian machines? If so I need to flip some byte-sequences.

Further more perf could be squeezed out (also for NS2.0), but I think the biggest improvement is by making some hot-methods (well definition of "hot" is here solely by me) allocation free.