### PR TITLE
Unsafe optimisations

### DIFF
--- a/NUlid/Ulid.cs
+++ b/NUlid/Ulid.cs
@@ -718,18 +718,11 @@ public struct Ulid : IEquatable<Ulid>, IComparable<Ulid>, IComparable, ISerializ
 
         return va.Equals(vb);
 #else
-        var a = x.ToByteArray();
-        var b = y.ToByteArray();
+        ref var rA = ref Unsafe.As<Ulid, long>(ref x);
+        ref var rB = ref Unsafe.As<Ulid, long>(ref y);
 
-        for (var i = 0; i < 16; i++)
-        {
-            if (a[i] != b[i])
-            {
-                return false;
-            }
-        }
-
-        return true;
+        // Compare each element
+        return rA == rB && Unsafe.Add(ref rA, 1) == Unsafe.Add(ref rB, 1);
 #endif
     }
 

--- a/NUlid/Ulid.cs
+++ b/NUlid/Ulid.cs
@@ -567,7 +567,11 @@ public struct Ulid : IEquatable<Ulid>, IComparable<Ulid>, IComparable, ISerializ
     /// </summary>
     /// <returns>A 16-element byte array.</returns>
     public byte[] ToByteArray()
-        => new byte[] { _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p };
+    {
+        var bytes = new byte[16];
+        Unsafe.WriteUnaligned(ref bytes[0], this);
+        return bytes;
+    }
 
     /// <summary>
     /// Returns a <see cref="Guid"/> that represents the value of this instance.

--- a/NUlid/Ulid.cs
+++ b/NUlid/Ulid.cs
@@ -639,35 +639,39 @@ public struct Ulid : IEquatable<Ulid>, IComparable<Ulid>, IComparable, ISerializ
     /// </returns>
     public int CompareTo(Ulid other)
     {
-        var d = other.ToByteArray();
-
-        return _a != d[0]
-            ? _a.CompareTo(d[0])
-            : _b != d[1]
-            ? _b.CompareTo(d[1])
-            : _c != d[2]
-            ? _c.CompareTo(d[2])
-            : _d != d[3]
-            ? _d.CompareTo(d[3])
-            : _e != d[4]
-            ? _e.CompareTo(d[4])
-            : _f != d[5]
-            ? _f.CompareTo(d[5])
-            : _g != d[6]
-            ? _g.CompareTo(d[6])
-            : _h != d[7]
-            ? _h.CompareTo(d[7])
-            : _i != d[8]
-            ? _i.CompareTo(d[8])
-            : _j != d[9]
-            ? _j.CompareTo(d[9])
-            : _k != d[10]
-            ? _k.CompareTo(d[10])
-            : _l != d[11]
-            ? _l.CompareTo(d[11])
-            : _m != d[12]
-            ? _m.CompareTo(d[12])
-            : _n != d[13] ? _n.CompareTo(d[13]) : _o != d[14] ? _o.CompareTo(d[14]) : _p != d[15] ? _p.CompareTo(d[15]) : 0;
+        return _a != other._a
+          ? _a.CompareTo(other._a)
+          : _b != other._b
+          ? _b.CompareTo(other._b)
+          : _c != other._c
+          ? _c.CompareTo(other._c)
+          : _d != other._d
+          ? _d.CompareTo(other._d)
+          : _e != other._e
+          ? _e.CompareTo(other._e)
+          : _f != other._f
+          ? _f.CompareTo(other._f)
+          : _g != other._g
+          ? _g.CompareTo(other._g)
+          : _h != other._h
+          ? _h.CompareTo(other._h)
+          : _i != other._i
+          ? _i.CompareTo(other._i)
+          : _j != other._j
+          ? _j.CompareTo(other._j)
+          : _k != other._k
+          ? _k.CompareTo(other._k)
+          : _l != other._l
+          ? _l.CompareTo(other._l)
+          : _m != other._m
+          ? _m.CompareTo(other._m)
+          : _n != other._n
+          ? _n.CompareTo(other._n)
+          : _o != other._o
+          ? _o.CompareTo(other._o)
+          : _p != other._p
+          ? _p.CompareTo(other._p)
+          : 0;
     }
 
     /// <summary>


### PR DESCRIPTION
## ToByteArray
Used `Unsafe.WriteUnaligned` to write the `Ulid` object to the array.

|                 Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|----------------------- |----------:|----------:|----------:|-------:|----------:|
| UlidNew.ToByteArrayNew |  6.823 ns | 0.0565 ns | 0.0529 ns | 0.0255 |      40 B |
|       Ulid.ToByteArray | 12.540 ns | 0.1201 ns | 0.1003 ns | 0.0255 |      40 B |

## CompareTo
Removed the usage of `ToByteArray`, instead directly accessing the fields of both objects, comparing each value.

|                 Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|----------------------- |----------:|----------:|----------:|-------:|----------:|
| UlidNew.CompareUnequal |  2.180 ns | 0.0458 ns | 0.0406 ns |      - |         - |
|   UlidNew.CompareEqual |  8.023 ns | 0.0400 ns | 0.0334 ns |      - |         - |
|    Ulid.CompareUnequal | 16.177 ns | 0.0487 ns | 0.0432 ns | 0.0255 |      40 B |
|      Ulid.CompareEqual | 19.121 ns | 0.0768 ns | 0.0718 ns | 0.0255 |      40 B |

## Equals
Used `Unsafe.As` to partially compare the `Ulid` internals as `long` values. This is a fallback for older versions.

|                Method |       Mean |     Error |    StdDev |   Gen0 | Allocated |
|---------------------- |-----------:|----------:|----------:|-------:|----------:|
| UlidNew.EqualsUnequal |  1.0789 ns | 0.0079 ns | 0.0074 ns |      - |         - |
|   UlidNew.EqualsEqual |  0.9003 ns | 0.0095 ns | 0.0084 ns |      - |         - |
|    Ulid.EqualsUnequal | 25.5941 ns | 0.0846 ns | 0.0750 ns | 0.0510 |      80 B |
|      Ulid.EqualsEqual | 32.5015 ns | 0.2498 ns | 0.2214 ns | 0.0510 |      80 B |

## Get Time
Used bitwise hacks to shuffle the bytes into a padded `long`. Added a `IsLittleEndian` check because I suspect it wouldn't work on BE devices.

|       Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|------------- |---------:|---------:|---------:|-------:|----------:|
| Ulid.TimeNew | 13.33 ns | 0.051 ns | 0.040 ns |      - |         - |
|    Ulid.Time | 30.80 ns | 0.175 ns | 0.155 ns | 0.0408 |      64 B |
