### PR TITLE
[feature] add min and max at static methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "NUlid.sln"
+}

--- a/NUlid/DateTimeExtensions.cs
+++ b/NUlid/DateTimeExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace NUlid;
+
+/// <summary>
+/// Extension methods for <see cref="DateTime"/> and <see cref="DateTimeOffset"/> to create <see cref="Ulid"/>s.
+/// </summary>
+public static class DateTimeExtensions
+{
+    /// <summary>
+    /// Returns a new <see cref="Ulid"/> based on the current <see cref="DateTime"/> value.
+    /// </summary>
+    /// <param name="dateTimeOffset">date time offset to base new ULID upon</param>
+    /// <returns>A new <see cref="Ulid"/></returns>
+    public static Ulid NewUlid(this DateTimeOffset dateTimeOffset)
+        => Ulid.NewUlid(dateTimeOffset);
+
+    /// <summary>
+    /// Returns the minimum <see cref="Ulid"/> based on the current <see cref="DateTime"/> value.
+    /// </summary>
+    /// <param name="dateTimeOffset">date time offset to base new ULID upon</param>
+    /// <returns>A new <see cref="Ulid"/></returns>
+    public static Ulid MinUlid(this DateTimeOffset dateTimeOffset)
+        => Ulid.MinAt(dateTimeOffset);
+
+    /// <summary>
+    /// Returns the maximum <see cref="Ulid"/> based on the current <see cref="DateTime"/> value.
+    /// </summary>
+    /// <param name="dateTimeOffset">date time offset to base new ULID upon</param>
+    /// <returns>A new <see cref="Ulid"/></returns>
+    public static Ulid MaxUlid(this DateTimeOffset dateTimeOffset)
+        => Ulid.MaxAt(dateTimeOffset);
+}

--- a/NUlid/NUlid.csproj
+++ b/NUlid/NUlid.csproj
@@ -1,47 +1,45 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-		<Authors>RobIII</Authors>
-		<Company>RobIII</Company>
-		<PackageId>NUlid</PackageId>
-		<NoPackageAnalysis>true</NoPackageAnalysis>
-		<Product>NUlid</Product>
-		<Copyright>(C) 2016 - 2022 Devcorner.nl</Copyright>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/RobThree/NUlid</PackageProjectUrl>
-		<PackageTags>Universally Unique Lexicographically Sortable Identifier, ULID, UUID, GUID</PackageTags>
-		<PackageReleaseNotes>Fixed bug in Monotonic UlidRng that could cause duplicate values when under high concurrency (see https://github.com/RobThree/NUlid/pull/17). Added MicrosecondUlidRng.</PackageReleaseNotes>
-		<IncludeSource>true</IncludeSource>
-		<Description>A .Net ULID implementation</Description>
-		<Version>1.7.0</Version>
-		<LangVersion>latest</LangVersion>
-		<PackageIcon>logo.png</PackageIcon>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<DocumentationFile>bin\Release\nulid.xml</DocumentationFile>
-		<Configurations>Debug;Release</Configurations>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-	</PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <Authors>RobIII, Muntadhar Haydar</Authors>
+        <Company>RobIII, Morabaa Software Solutions, LTD.</Company>
+        <PackageId>NUlid</PackageId>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <Product>NUlid</Product>
+        <Copyright>(C) 2016 - 2023 Devcorner.nl, Morabaa Software Solutions, LTD.</Copyright>
+        <Nullable>enable</Nullable>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/MorabaaSoftwareSolutions/NUlid</PackageProjectUrl>
+        <PackageTags>Universally Unique Lexicographically Sortable Identifier, ULID, UUID, GUID</PackageTags>
+        <IncludeSource>true</IncludeSource>
+        <Description>A .Net ULID implementation</Description>
+        <Version>1.8.0</Version>
+        <LangVersion>preview</LangVersion>
+        <PackageIcon>logo.png</PackageIcon>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <DocumentationFile>bin\Release\nulid.xml</DocumentationFile>
+        <Configurations>Debug;Release</Configurations>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DefineConstants>TRACE;RELEASE</DefineConstants>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DefineConstants>TRACE;RELEASE</DefineConstants>
+    </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
-		<DocumentationFile>bin\release\NUlid.xml</DocumentationFile>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
+        <DocumentationFile>bin\release\NUlid.xml</DocumentationFile>
+    </PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="System.Memory" Version="4.5.5" />
-	</ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Memory" Version="4.5.5" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\logo.png">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="..\logo.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "6.0.100",
+        "allowPrerelease": false,
+        "rollForward": "latestMinor"
+    }
+}


### PR DESCRIPTION
First, I would like to say thanks for the great work!

We've been looking into ULID to use instead of UUID/GUID in our projects and figured we could get rid of the dedicated "CreatedAt" column/prop that we usually have.

To make querying easier, we thought such methods would be great to have in the lib so we could do something like

```cs
var anHourAgo = DateTimeOffset.UtcNow.AddHours(-1);
var idGte = Ulid.MinAt(anHourAgo);
queryable = queryable.Where(x => x.Id >= idGte);
```

Was also looking into writing a couple more extensions, maybe in another PR.
Basically

```cs
DateTimeOffset.UtcNow.NewUlid();
DateTimeOffset.UtcNow.MinUlid();
DateTimeOffset.UtcNow.MaxUlid();
```

Thanks again